### PR TITLE
Fixed typographical error, changed abilty to ability in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A set of integration and unit tests can be found in _src/test/java_ (tests) & _s
 * Support for Java 7 Data and Time classes
 * Include the ability to define a database driven properties source not just properties files
 * Implement error recovery inside PropertiesWatcher.class, including better thread recovery
-* Abilty to perform additional re-bind logic when a property is changed, i.e. if a class has an open DB connection whcih needs tobe re-established using newly set properties.
+* Ability to perform additional re-bind logic when a property is changed, i.e. if a class has an open DB connection whcih needs tobe re-established using newly set properties.
 * Replace callback Properties EventHandler with Guava EventBus
 * Ability to configure usage via spring's @Configuration 
 


### PR DESCRIPTION
jamesmorgan, I've corrected a typographical error in the documentation of the [ReloadablePropertiesAnnotation](https://github.com/jamesmorgan/ReloadablePropertiesAnnotation) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.