### PR TITLE
java.util.Date support using Spring's CustomDateEditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,15 +58,15 @@ A set of integration and unit tests can be found in _src/test/java_ (tests) & _s
 
 ### Future Changes ###
 * Ability to use Spring Expression language to map properties files
-* Support for Java 7 Data and Time classes
+* Support for Java 7 Date and Time classes
 * Include the ability to define a database driven properties source not just properties files
 * Implement error recovery inside PropertiesWatcher.class, including better thread recovery
-* Ability to perform additional re-bind logic when a property is changed, i.e. if a class has an open DB connection whcih needs tobe re-established using newly set properties.
+* Ability to perform additional re-bind logic when a property is changed, i.e. if a class has an open DB connection which needs to be re-established using newly set properties.
 * Replace callback Properties EventHandler with Guava EventBus
 * Ability to configure usage via spring's @Configuration 
 
 ### Contributions ###
-* Thankyou [normanatashbar](https://github.com/normanatashbar) for adding composite string replacement
+* Thank you [normanatashbar](https://github.com/normanatashbar) for adding composite string replacement
 
 ### Supported Property Type Conversions Available ###
 * LocalDate.class

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ These properties also auto reload if the given properties file changes during ru
 <pre>
 	@ReloadableProperty("dynamicProperty.longValue")
 	private long primitiveWithDefaultValue = 55;
-
+	
 	@ReloadableProperty("dynamicProperty.substitutionValue")
 	private String stringProperty;
 	
@@ -69,23 +69,23 @@ A set of integration and unit tests can be found in _src/test/java_ (tests) & _s
 * Thankyou [normanatashbar](https://github.com/normanatashbar) for adding composite string replacement
 
 ### Supported Property Type Conversions Available ###
-* Joda Time Library (2.1) - [link](http://joda-time.sourceforge.net/)
- * LocalDate.class
- * LocalTime.class
- * LocalDateTime.class
- * Period.class
+* LocalDate.class
+* LocalTime.class
+* LocalDateTime.class
+* Period.class
 
 
 * Spring Supported (3.1.2-RELEASE)
- * String.class
- * boolean.class, Boolean.class
- * byte.class, Byte.class
- * char.class, Character.class
- * short.class, Short.class
- * int.class, Integer.class
- * long.class,	Long.class
- * float.class, Float.class
- * double.class, Double.class
+* String.class
+* Date.class
+* boolean.class, Boolean.class
+* byte.class, Byte.class
+* char.class, Character.class
+* short.class, Short.class
+* int.class, Integer.class
+   * long.class,Long.class
+* float.class, Float.class
+* double.class, Double.class
 
 ### Dependencies ###
 
@@ -93,6 +93,7 @@ A set of integration and unit tests can be found in _src/test/java_ (tests) & _s
 * Java 7 SDK
 * Spring (3.2.5-RELEASE)
 * Google Guava  (14.0.1)
+* Joda Time Library (2.1) - [link](http://joda-time.sourceforge.net/)
 
 #### Logging ####
 * logback (1.0.13)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ A set of integration and unit tests can be found in _src/test/java_ (tests) & _s
 
 ### Contributions ###
 * Thank you [normanatashbar](https://github.com/normanatashbar) for adding composite string replacement
+* Thank you [shiva2991](https://github.com/normanatashbar) for adding java.util.Date type conversion.
 
 ### Supported Property Type Conversions Available ###
 * LocalDate.class

--- a/src/main/java/com/morgan/design/properties/conversion/CustomEditorsRegistrar.java
+++ b/src/main/java/com/morgan/design/properties/conversion/CustomEditorsRegistrar.java
@@ -1,0 +1,25 @@
+package com.morgan.design.properties.conversion;
+
+import java.beans.PropertyEditor;
+import java.util.Map;
+
+import org.springframework.beans.PropertyEditorRegistrar;
+import org.springframework.beans.PropertyEditorRegistry;
+
+public class CustomEditorsRegistrar implements PropertyEditorRegistrar {
+
+	private Map<Class<?>, PropertyEditor> extraEditors;
+	
+	public CustomEditorsRegistrar(Map<Class<?>, PropertyEditor> extraEditors)
+	{
+		this.extraEditors = extraEditors;
+	}
+	
+	@Override
+	public void registerCustomEditors(PropertyEditorRegistry registry) {
+		for (Map.Entry<Class<?>, PropertyEditor> entry : extraEditors.entrySet()) {
+			registry.registerCustomEditor(entry.getKey(), entry.getValue());
+		}
+	}
+
+}

--- a/src/main/java/com/morgan/design/properties/conversion/DefaultPropertyConversionService.java
+++ b/src/main/java/com/morgan/design/properties/conversion/DefaultPropertyConversionService.java
@@ -3,12 +3,17 @@ package com.morgan.design.properties.conversion;
 import java.lang.reflect.Field;
 import java.util.Map;
 
+import javax.annotation.PostConstruct;
+
 import org.joda.time.LocalDate;
 import org.joda.time.LocalDateTime;
 import org.joda.time.LocalTime;
 import org.joda.time.Period;
 import org.springframework.beans.SimpleTypeConverter;
+import org.springframework.beans.TypeConverter;
 import org.springframework.beans.factory.BeanInitializationException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.stereotype.Component;
 
 import com.google.common.base.Function;
@@ -25,6 +30,9 @@ import com.morgan.design.util.JodaUtils;
 @Component
 public class DefaultPropertyConversionService implements PropertyConversionService {
 
+	@Autowired
+	private ConfigurableBeanFactory configurableBeanFactory;
+	private static TypeConverter DEFAULT;
 	private static Map<Class<? extends Object>, Function<Object, ?>> CONVERTS = Maps.newHashMap();
 	static {
 		CONVERTS.put(Period.class, new PeriodConverter());
@@ -32,9 +40,12 @@ public class DefaultPropertyConversionService implements PropertyConversionServi
 		CONVERTS.put(LocalDate.class, new LocalDateConverter());
 		CONVERTS.put(LocalTime.class, new LocalTimeConverter());
 	}
-
-	private static SimpleTypeConverter DEFAULT = new SimpleTypeConverter();
-
+	
+	@PostConstruct
+	public void init() {
+		DEFAULT = configurableBeanFactory.getTypeConverter();
+	}
+	
 	@Override
 	public Object convertPropertyForField(final Field field, final Object property) {
 		try {

--- a/src/main/resources/spring/spring-defaultConfiguration.xml
+++ b/src/main/resources/spring/spring-defaultConfiguration.xml
@@ -11,6 +11,35 @@
 		class="com.morgan.design.properties.conversion.DefaultPropertyConversionService"
 		id="conversionService" />
 
+	<!-- register property editors for date and other types -->
+	<bean class="org.springframework.beans.factory.config.CustomEditorConfigurer">
+		<property name="propertyEditorRegistrars">
+			<array>
+				<ref bean="customEditorRegistrar"/>
+			</array>
+		</property>
+	</bean>
+	
+	<!-- bean that helps to add as many editors as we require -->
+	<bean id="customEditorRegistrar" class="com.morgan.design.properties.conversion.CustomEditorsRegistrar">
+		<constructor-arg>
+			<map>
+				<entry key="java.util.Date" value-ref="dateEditor"/>
+			</map>
+		</constructor-arg>
+	</bean>
+	
+	<!-- spring's default date property editor -->
+	<bean id="dateEditor"
+   		class="org.springframework.beans.propertyeditors.CustomDateEditor">
+		<constructor-arg>
+			<bean class="java.text.SimpleDateFormat">
+				<constructor-arg value="dd-MM-yyyy" />
+			</bean>
+		</constructor-arg>
+		<constructor-arg value="true" />
+	</bean>
+	
 	<bean
 		class="com.morgan.design.properties.event.GuavaPropertyChangedEventNotifier"
 		autowire="constructor" id="eventNotifier">

--- a/src/test/java/com/morgan/design/properties/conversion/DefaultPropertyConversionServiceUnitTest.java
+++ b/src/test/java/com/morgan/design/properties/conversion/DefaultPropertyConversionServiceUnitTest.java
@@ -3,21 +3,24 @@ package com.morgan.design.properties.conversion;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 import org.joda.time.LocalDate;
 import org.joda.time.LocalDateTime;
 import org.joda.time.LocalTime;
 import org.joda.time.Period;
-import org.junit.Before;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 
-public class DefaultPropertyConversionServiceUnitTest {
+@ContextConfiguration(locations = {"classpath:/spring/spring-reloadablePropertyPostProcessorIntTest.xml"})
+public class DefaultPropertyConversionServiceUnitTest extends AbstractJUnit4SpringContextTests {
 
+	@Autowired
 	private PropertyConversionService conversionService;
-
-	@Before
-	public void setUp() throws Exception {
-		this.conversionService = new DefaultPropertyConversionService();
-	}
 
 	@Test
 	public void shouldConvertPeriodForPropertyForField() throws NoSuchFieldException, SecurityException {
@@ -52,11 +55,18 @@ public class DefaultPropertyConversionServiceUnitTest {
 		assertThat((Boolean) convertPropertyForField("booleanValue", "true"), is(true));
 	}
 
+	@Test
+	public void shouldConvertDateValue() throws NoSuchFieldException, SecurityException, ParseException {
+		Date expected = new SimpleDateFormat("dd-MM-yyyy").parse("9-4-2017");
+		assertThat((Date) convertPropertyForField("dateValue", "9-4-2017"), is(expected));
+	}
+	
 	static class TestObject {
 		Period period = new Period();
 		LocalTime localTime = new LocalTime();
 		LocalDate localDate = new LocalDate();
 		LocalDateTime localDateTime = new LocalDateTime();
+		Date dateValue = new Date();
 		boolean booleanValue;
 	}
 

--- a/src/test/java/com/morgan/design/properties/internal/ReloadablePropertyPostProcessorIntTest.java
+++ b/src/test/java/com/morgan/design/properties/internal/ReloadablePropertyPostProcessorIntTest.java
@@ -5,6 +5,9 @@ import static org.junit.Assert.assertThat;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import org.joda.time.LocalDate;
 import org.joda.time.LocalDateTime;
@@ -98,5 +101,10 @@ public class ReloadablePropertyPostProcessorIntTest extends AbstractJUnit4Spring
 	public void shouldInjectLocalTimeValue() {
 		assertThat(this.bean.getLocalTimeProperty(), is(new LocalTime(12, 22, 45)));
 	}
-
+	
+	@Test
+	public void shouldInjectDateValue() throws ParseException {
+		Date d = new SimpleDateFormat("dd-MM-yyyy").parse("14-4-2017"); // exception is never throw
+		assertThat(this.bean.getDateProperty(), is(d));
+	}
 }

--- a/src/test/java/com/morgan/design/properties/testBeans/AutowiredPropertyBean.java
+++ b/src/test/java/com/morgan/design/properties/testBeans/AutowiredPropertyBean.java
@@ -2,6 +2,7 @@ package com.morgan.design.properties.testBeans;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Date;
 
 import org.joda.time.LocalDate;
 import org.joda.time.LocalDateTime;
@@ -71,6 +72,10 @@ public class AutowiredPropertyBean {
 
 	@ReloadableProperty("dynamicProperty.localTimeValue")
 	private LocalTime localTimeProperty;
+	
+	// java date
+	@ReloadableProperty("dynamicProperty.dateValue")
+	private Date dateProperty;
 
 	// recursive substitution
 
@@ -151,4 +156,7 @@ public class AutowiredPropertyBean {
 		return this.substitutedProperty;
 	}
 
+	public Date getDateProperty() {
+		return this.dateProperty;
+	}
 }

--- a/src/test/resources/test-files/example.properties
+++ b/src/test/resources/test-files/example.properties
@@ -13,3 +13,4 @@ dynamicProperty.booleanValue=true
 dynamicProperty.localDateTimeValue=2009-07-05 12:56:02
 invalid.period=12:22:
 dynamicProperty.bigIntegerValue=224411
+dynamicProperty.dateValue=14-4-2017


### PR DESCRIPTION
Hi James, this change provide support for converting pre-defined date patterns to java.util.Date. 

Changes included. 

- I used Spring's `ConfigurableBeanFactory.getTypeConverter()` to get default converter. 
- Inject Spring's date property editor (CustomDateEditor) in `spring-defaultConfiguration.xml`.
- Modification of test class for autowiring.
Please notify me if more changes has to do.
